### PR TITLE
Fix timeout error for pip install

### DIFF
--- a/client_requirements.txt
+++ b/client_requirements.txt
@@ -3,5 +3,5 @@ grpcio<=1.46.2
 grpcio-tools==1.46.1
 opencv-python==4.7.0.68
 protobuf
-tensorflow
+tensorflow>=2.10
 tensorflow-serving-api


### PR DESCRIPTION
In proxy, pip install is getting timeout for tensorflow.

Added version control for tensorflow to avoid multiple version download

Tracked-On: OAM-108702